### PR TITLE
Add name to Package Metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 # The content of this file is only necessary for python packages
 [metadata]
+name = edi_energy_scraper
 author = Hochfrequenz Unternehmensberatung GmbH
 author_email = your@email.address
 description = a scraper to mirror edi-energy.de


### PR DESCRIPTION
Checking dist/UNKNOWN-0.0.2-py3-none-any.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name.
Make sure the distribution includes the files where those fields are specified, and is using a supported Metadata-Version: 1.0, 1.1...