### PR TITLE
Fix beautifulsoup deprecation warning: Use `string` instead of `text`

### DIFF
--- a/src/edi_energy_scraper/__init__.py
+++ b/src/edi_energy_scraper/__init__.py
@@ -178,7 +178,7 @@ class EdiEnergyScraper:
         """
         Removes thes HTML comments from the given soup.
         """
-        for html_comment in soup.findAll(text=lambda text: isinstance(text, Comment)):
+        for html_comment in soup.findAll(string=lambda text: isinstance(text, Comment)):
             html_comment.extract()
 
     def get_documents_page_link(self, index_soup) -> str:


### PR DESCRIPTION
edi_energy_scraper\__init__.py:176: DeprecationWarning: The 'text' argument to find()-type methods is deprecated. Use 'string' instead.
for html_comment in soup.findAll(text=lambda text: isinstance(text, Comment)):