### PR TITLE
❌ Drop Support for Python 3.7

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
 packages = find:
 zip_safe = False
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     beautifulsoup4>=4.11.1
     requests>=2.28.0


### PR DESCRIPTION
>  TypeError: object BeautifulSoup can't be used in 'await' expression