### PR TITLE
fix(ci): pin hatchling to 1.26.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@
 # Build system information and other project-specific configuration below.
 
 [build-system]
-requires = ["hatchling>=1.8.0", "hatch-vcs", "hatch-fancy-pypi-readme"]
+requires = ["hatchling==1.26.3", "hatch-vcs", "hatch-fancy-pypi-readme"]
+# pinned hatchling version because https://github.com/astral-sh/rye/issues/1446
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
https://github.com/astral-sh/rye/issues/1446#issuecomment-2546425240

fixes
test_packaging: install_deps> python -I -m pip install './.[test_packaging]'
test_packaging: freeze> python -m pip freeze --all
test_packaging: aiodns==3.2.0,aiohappyeyeballs==2.4.4,aiohttp==3.11.11,aiohttp-requests==0.2.4,aiosignal==1.3.2,attrs==24.3.0,beautifulsoup4==4.12.3,Brotli==1.1.0,build==1.2.2.post1,certifi==2024.12.14,cffi==1.17.1,charset-normalizer==3.4.1,coworker==2.0.1,cryptography==44.0.0,docutils==0.21.2,edi_energy_scraper @ file:///home/runner/work/edi_energy_scraper/edi_energy_scraper,efoli==1.4.0,frozenlist==1.5.0,idna==3.10,importlib_metadata==8.5.0,jaraco.classes==3.4.0,jaraco.context==6.0.1,jaraco.functools==4.1.0,jeepney==0.8.0,keyring==25.6.0,markdown-it-py==3.0.0,mdurl==0.1.2,more-itertools==10.5.0,multidict==6.1.0,nh3==0.2.20,packaging==24.2,pip==24.3.1,pkginfo==1.10.0,propcache==0.2.1,pycares==4.5.0,pycparser==2.22,Pygments==2.18.0,pypdf==5.1.0,pyproject_hooks==1.2.0,pytz==2024.2,readme_renderer==44.0,requests==2.32.3,requests-toolbelt==1.0.0,rfc3986==2.0.0,rich==13.9.4,SecretStorage==3.3.3,soupsieve==2.6,twine==5.1.1,urllib3==2.3.0,yarl==1.18.3,zipp==3.21.0
test_packaging: commands[0]> python -m build
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - hatch-fancy-pypi-readme
  - hatch-vcs
  - hatchling>=1.8.0
* Getting build dependencies for sdist...
* Building sdist...
/tmp/build-env-k7f83_yi/lib/python3.13/site-packages/setuptools_scm/git.py:167: UserWarning: "/home/runner/work/edi_energy_scraper/edi_energy_scraper" is shallow and may cause errors
  warnings.warn(f'"{wd.path}" is shallow and may cause errors')
* Building wheel from sdist
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - hatch-fancy-pypi-readme
  - hatch-vcs
  - hatchling>=1.8.0
* Getting build dependencies for wheel...
* Building wheel...
Successfully built edi_energy_scraper-0.1.dev1+g0a0788a.tar.gz and edi_energy_scraper-0.1.dev1+g0a0788a-py3-none-any.whl
test_packaging: commands[1]> twine check 'dist/*'
Checking dist/edi_energy_scraper-0.1.dev1+g0a0788a-py3-none-any.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name,
         Version.
         Make sure the distribution includes the files where those fields are
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,
         2.0, 2.1, 2.2, 2.3.
test_packaging: exit 1 (0.31 seconds) /home/runner/work/edi_energy_scraper/edi_energy_scraper> twine check 'dist/*' pid=2025
  test_packaging: FAIL code 1 (16.54=setup[12.46]+cmd[3.77,0.31] seconds)
  evaluation failed :( (16.61 seconds)
